### PR TITLE
Update version to 6.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About docker-py
-===============
+About docker-py-feedstock
+=========================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/docker-py-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/docker/docker-py
 
 Package license: Apache-2.0
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/docker-py-feedstock/blob/main/LICENSE.txt)
 
 Summary: A Python library for the Docker Engine API.
 
@@ -147,6 +147,7 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@bollwyvl](https://github.com/bollwyvl/)
 * [@mariusvniekerk](https://github.com/mariusvniekerk/)
 * [@ocefpaf](https://github.com/ocefpaf/)
 * [@scopatz](https://github.com/scopatz/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "6.0.0" %}
+{% set version = "6.1.0" %}
 
 package:
   name: docker-py
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/docker/docker-{{ version }}.tar.gz
-  sha256: 19e330470af40167d293b0352578c1fa22d74b34d3edf5d4ff90ebc203bbb2f1
+  sha256: cb697eccfeff55d232f7a7f4f88cd3770d27327c38d6c266b8f55c9f14a8491e
 
 build:
   noarch: python


### PR DESCRIPTION
Hey everyone,
after seeing `bot-automerge` I'm not sure if I was supposed to do this by hand, but here we go.
Docker 6.0.0 is not compatible with requests 2.29.0 and urllib3 2.0, [as seen in this issue](https://github.com/docker/docker-py/issues/3113).
Docker 6.1.0 [fixes this issue](https://github.com/docker/docker-py/pull/3116). This is my attempt to update this feedstock.
Thanks!

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
**Checklist**
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
